### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -1,6 +1,8 @@
 # This is a basic workflow to help you get started with Actions
 
 name: CI
+permissions:
+  contents: read
 
 # Controls when the workflow will run
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/SixFigureSecurity/Github-Examples/security/code-scanning/1](https://github.com/SixFigureSecurity/Github-Examples/security/code-scanning/1)

To fix this, we should explicitly declare minimal `GITHUB_TOKEN` permissions for the workflow. The job only needs to read repository contents to perform `actions/checkout@v4`; it doesn’t create or modify issues, PRs, or contents. The best fix is to add a `permissions` block with `contents: read`. This can be done either at the workflow root (applies to all jobs) or inside the `build` job; adding it at the root is simplest and does not change existing behavior beyond tightening token permissions.

Concretely, in `.github/workflows/blank.yml`, insert a `permissions:` block after the `name: CI` line (line 3). Set:

```yaml
permissions:
  contents: read
```

No imports or other definitions are needed since this is a YAML workflow file. Functionality of the job remains the same, but the `GITHUB_TOKEN` is constrained to read-only repository contents, resolving the CodeQL warning.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
